### PR TITLE
fix url param praser error

### DIFF
--- a/VIMediaCache/ResourceLoader/VIResourceLoaderManager.m
+++ b/VIMediaCache/ResourceLoader/VIResourceLoaderManager.m
@@ -9,7 +9,7 @@
 #import "VIResourceLoaderManager.h"
 #import "VIResourceLoader.h"
 
-static NSString *kCacheScheme = @"VIMediaCache";
+static NSString *kCacheScheme = @"__VIMediaCache___:";
 
 @interface VIResourceLoaderManager () <VIResourceLoaderDelegate>
 
@@ -42,18 +42,26 @@ static NSString *kCacheScheme = @"VIMediaCache";
 
 - (BOOL)resourceLoader:(AVAssetResourceLoader *)resourceLoader shouldWaitForLoadingOfRequestedResource:(AVAssetResourceLoadingRequest *)loadingRequest  {
     NSURL *resourceURL = [loadingRequest.request URL];
-    if ([resourceURL.scheme isEqualToString:kCacheScheme]) {
+    if ([resourceURL.absoluteString hasPrefix:kCacheScheme]) {
         VIResourceLoader *loader = [self loaderForRequest:loadingRequest];
         if (!loader) {
+            /*
             NSURLComponents *components = [NSURLComponents componentsWithString:resourceURL.absoluteString];
             NSURL *originURL;
             if ([components respondsToSelector:@selector(queryItems)]) {
                 NSURLQueryItem *queryItem = [components.queryItems lastObject];
-                originURL = [NSURL URLWithString:queryItem.value];
+                NSString *urlString = [queryItem.value stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                originURL = [NSURL URLWithString:urlString];
             } else {
                 NSString *url = [[components.query componentsSeparatedByString:@"="] lastObject];
+                url = [url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
                 originURL = [NSURL URLWithString:url];
             }
+             */
+             NSURL *originURL = nil;
+            NSString *originStr = [resourceURL absoluteString];
+            originStr = [originStr stringByReplacingOccurrencesOfString:kCacheScheme withString:@""];
+            originURL = [NSURL URLWithString:originStr];
             loader = [[VIResourceLoader alloc] initWithURL:originURL];
             loader.delegate = self;
             NSString *key = [self keyForResourceLoaderWithURL:resourceURL];
@@ -84,7 +92,7 @@ static NSString *kCacheScheme = @"VIMediaCache";
 #pragma mark - Helper
 
 - (NSString *)keyForResourceLoaderWithURL:(NSURL *)requestURL {
-    if([requestURL.scheme isEqualToString:kCacheScheme]){
+    if([[requestURL absoluteString] hasPrefix:kCacheScheme]){
         NSString *s = requestURL.absoluteString;
         return s;
     }
@@ -105,12 +113,14 @@ static NSString *kCacheScheme = @"VIMediaCache";
     if (!url) {
         return nil;
     }
-    
+    /*
     NSURLComponents *componnents = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
     componnents.scheme = kCacheScheme;
     
     NSString *appendStr = componnents.query.length > 0 ? @"&" : @"?";
     NSURL *assetURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@MCurl=%@", componnents.URL.absoluteString, appendStr, url.absoluteString]];
+     */
+    NSURL *assetURL = [NSURL URLWithString:[kCacheScheme stringByAppendingString:[url absoluteString]]];
     
     return assetURL;
 }

--- a/VIMediaCacheDemo/ViewController.m
+++ b/VIMediaCacheDemo/ViewController.m
@@ -103,7 +103,7 @@
 #pragma mark - Setup
 
 - (void)setupPlayer {
-        NSURL *url = [NSURL URLWithString:@"http://mpvideo-test.b0.upaiyun.com/5813998fb092e5771.mp4"];
+        NSURL *url = [NSURL URLWithString:@"http://gedftnj8mkvfefuaefm.exp.bcevod.com/mda-hc2s2difdjz6c5y9/hd/mda-hc2s2difdjz6c5y9.mp4?playlist%3D%5B%22hd%22%5D&auth_key=1500559192-0-0-dcb501bf19beb0bd4e0f7ad30c380763&bcevod_channel=searchbox_feed&srchid=3ed366b1b0bf70e0&channel_id=2&d_t=2&b_v=9.1.0.0"];
 //        NSURL *url = [NSURL URLWithString:@"https://mvvideo5.meitudata.com/56a9e1389b9706520.mp4"];
 //        NSURL *url = [NSURL URLWithString:@"http://media-test.1iptv.com/recordings/z1.meipai-live-test.57d15a1f1013858cda04d060/z157d15a1f1013858cda04d060.m3u8?start=-1&end=-1"];
 //    NSURL *url = [NSURL URLWithString:@"http://nightwander.s.qupai.me/v/7f7aa378-b80e-44e8-a326-32b19614218f.mp4?token=AMIRnTPJEMn9iZslnQZp3bKNGNtBnSC10MYJDIyMDNyAyMkNGOwQmNkJGO3AjYwIDIyACNzIDMyczM4QTM"];


### PR DESCRIPTION
http://gedftnj8mkvfefuaefm.exp.bcevod.com/mda-hc2s2difdjz6c5y9/hd/mda-hc2s2difdjz6c5y9.mp4?playlist%3D%5B%22hd%22%5D&auth_key=1500559192-0-0-dcb501bf19beb0bd4e0f7ad30c380763&bcevod_channel=searchbox_feed&srchid=3ed366b1b0bf70e0&channel_id=2&d_t=2&b_v=9.1.0.0
url带有参数的解析有问题。修复办法，不解析url参数，直接在scheme前拼上标示符