### PR TITLE
fix: Avoid reading the entire file multiple times when loading from cache

### DIFF
--- a/VIMediaCache/Cache/VIMediaCacheWorker.m
+++ b/VIMediaCache/Cache/VIMediaCacheWorker.m
@@ -12,7 +12,7 @@
 
 @import UIKit;
 
-static NSInteger const kPackageLength = 204800; // 200kb per package
+static NSInteger const kPackageLength = 512 * 1024; // 512 kb per package
 static NSString *kMCMediaCacheResponseKey = @"kMCMediaCacheResponseKey";
 static NSString *VIMediaCacheErrorDoamin = @"com.vimediacache";
 

--- a/VIMediaCache/ResourceLoader/VIResourceLoadingRequestWorker.m
+++ b/VIMediaCache/ResourceLoader/VIResourceLoadingRequestWorker.m
@@ -59,6 +59,7 @@
 
 - (void)finish {
     if (!self.request.isFinished) {
+        [self.mediaDownloader cancel];
         [self.request finishLoadingWithError:[self loaderCancelledError]];
     }
 }


### PR DESCRIPTION
Fix the bug in VIActionWorker, which mentioned in this issue:  https://github.com/vitoziv/VIMediaCache/issues/82

