### PR TITLE
Bug Fix : If assetURL == nil the App crashes.

### DIFF
--- a/VIMediaCache/ResourceLoader/VIResourceLoaderManager.m
+++ b/VIMediaCache/ResourceLoader/VIResourceLoaderManager.m
@@ -101,6 +101,9 @@ static NSString *kCacheScheme = @"VIMediaCache:";
     }
 
     NSURL *assetURL = [NSURL URLWithString:[kCacheScheme stringByAppendingString:[url absoluteString]]];
+    if (assetURL == nil) {
+            return url;
+    }
     return assetURL;
 }
 


### PR DESCRIPTION
I'm having a podcast player in my app and using the pod. 

For some reason it crashes at assetUrl = nil 

So i found a quick fix at my end for returning same url if assetUrl is nil. 